### PR TITLE
CHA-513 Fix iOS 15 safari images

### DIFF
--- a/entry.css
+++ b/entry.css
@@ -484,18 +484,6 @@
 /**
  * Image
  **/
-.Pinpoint.document .image_block .image {
-	@apply flex justify-center;
-}
-.Pinpoint.document .image_block.left .image {
-	@apply justify-start;
-}
-.Pinpoint.document .image_block.center .image {
-	@apply justify-center;
-}
-.Pinpoint.document .image_block.right .image {
-	@apply justify-end;
-}
 .Pinpoint.document .image_block .alt {
 	@apply mt-2 opacity-80 text-center italic;
 }
@@ -510,6 +498,12 @@
 }
 .Pinpoint.document .image_block .image img {
 	@apply rounded-lg;
+}
+.Pinpoint.document .image_block.center .image img {
+	@apply mx-auto;
+}
+.Pinpoint.document .image_block.right .image img {
+	@apply ml-auto;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "1.0.24",
+	"version": "1.0.25",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "1.0.24",
+	"version": "1.0.25",
 	"description": "The Pinpoint UI Library for React",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
Image is rendered at full height when setting height against the container flexbox orientation causing distortion. Use auto margins to handle alignment.