### PR TITLE
jhaynie/cha 519 when creating monospaced font inside a

### DIFF
--- a/entry.css
+++ b/entry.css
@@ -41,6 +41,14 @@
 	color: unset;
 }
 
+/* if embeded code block, only set the font and unset the styling to adapt to the parent */
+.Pinpoint.document blockquote code,
+.Pinpoint.document .notice code {
+	background-color: unset !important;
+	border: unset !important;
+	color: unset !important;
+}
+
 /**
  * Headings
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "1.0.27",
+	"version": "1.0.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "1.0.27",
+	"version": "1.0.28",
 	"description": "The Pinpoint UI Library for React",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/src/components/Renderer/__data__/blockquote_with_code_mark.ts
+++ b/src/components/Renderer/__data__/blockquote_with_code_mark.ts
@@ -1,0 +1,24 @@
+export default {
+	type: 'doc',
+	content: [
+		{
+			type: 'blockquote',
+			content: [
+				{
+					type: 'paragraph',
+					content: [
+						{
+							type: 'text',
+							marks: [
+								{
+									type: 'code_inline',
+								},
+							],
+							text: 'GET api/regulations/:id',
+						},
+					],
+				},
+			],
+		},
+	],
+};

--- a/src/components/Renderer/__data__/notice_with_code_mark.ts
+++ b/src/components/Renderer/__data__/notice_with_code_mark.ts
@@ -1,0 +1,27 @@
+export default {
+	type: 'doc',
+	content: [
+		{
+			type: 'notice',
+			attrs: {
+				style: 'info',
+			},
+			content: [
+				{
+					type: 'paragraph',
+					content: [
+						{
+							type: 'text',
+							text: 'This is an info notice with monospaced font',
+							marks: [
+								{
+									type: 'code_inline',
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+	],
+};

--- a/src/components/Renderer/__stories__/Renderer.stories.tsx
+++ b/src/components/Renderer/__stories__/Renderer.stories.tsx
@@ -3,7 +3,9 @@ import { Meta } from '@storybook/react';
 import { Content, Document, emptyDoc } from '../';
 import { CoverMediaType } from '../../../lib/types/content';
 import Pinpoint from '../../Pinpoint';
+import blockquote_with_code_mark from '../__data__/blockquote_with_code_mark';
 import image_block_position_and_scale from '../__data__/image_block_position_and_scale';
+import notice_with_code_mark from '../__data__/notice_with_code_mark';
 import simple_blockquote from '../__data__/simple_blockquote';
 import simple_break from '../__data__/simple_break';
 import simple_bullet_list from '../__data__/simple_bullet_list';
@@ -51,6 +53,8 @@ export const Simple_Paragraph: React.VFC<{}> = () => <Document node={simple_para
 
 export const Simple_Blockquote: React.VFC<{}> = () => <Document node={simple_blockquote} />;
 
+export const Blockquote_With_Code_Mark: React.VFC<{}> = () => <Document node={blockquote_with_code_mark} />;
+
 export const Simple_Break: React.VFC<{}> = () => <Document node={simple_break} />;
 
 export const Simple_Hr: React.VFC<{}> = () => <Document node={simple_hr} />;
@@ -76,6 +80,8 @@ export const Simple_Warning_Notice: React.VFC<{}> = () => <Document node={simple
 export const Simple_Error_Notice: React.VFC<{}> = () => <Document node={simple_error_notice} />;
 
 export const Simple_Info_Notice: React.VFC<{}> = () => <Document node={simple_info_notice} />;
+
+export const Info_Notice_Monospaced: React.VFC<{}> = () => <Document node={notice_with_code_mark} />;
 
 export const Simple_Inline_Image: React.VFC<{}> = () => <Document node={simple_inline_image} />;
 

--- a/src/components/Renderer/__test__/RendererContent.test.tsx
+++ b/src/components/Renderer/__test__/RendererContent.test.tsx
@@ -1,6 +1,8 @@
 import renderer from 'react-test-renderer';
 import { CoverMedia, Document, emptyDoc } from '../';
 import { CoverMediaType } from '../../../lib/types/content';
+import blockquote_with_code_mark from '../__data__/blockquote_with_code_mark';
+import notice_with_code_mark from '../__data__/notice_with_code_mark';
 import simple_blockquote from '../__data__/simple_blockquote';
 import simple_break from '../__data__/simple_break';
 import simple_bullet_list from '../__data__/simple_bullet_list';
@@ -46,6 +48,13 @@ test('Test simple paragraph', () => {
 
 test('Test simple blockquote', () => {
 	const doc = simple_blockquote;
+	const component = renderer.create(<Document node={doc} />);
+	const tree = component.toJSON();
+	expect(tree).toMatchSnapshot();
+});
+
+test('Test blockquote with code', () => {
+	const doc = blockquote_with_code_mark;
 	const component = renderer.create(<Document node={doc} />);
 	const tree = component.toJSON();
 	expect(tree).toMatchSnapshot();
@@ -137,6 +146,13 @@ test('Test simple error notice', () => {
 
 test('Test simple info notice', () => {
 	const doc = simple_info_notice;
+	const component = renderer.create(<Document node={doc} />);
+	const tree = component.toJSON();
+	expect(tree).toMatchSnapshot();
+});
+
+test('Test info notice with monospaced font', () => {
+	const doc = notice_with_code_mark;
 	const component = renderer.create(<Document node={doc} />);
 	const tree = component.toJSON();
 	expect(tree).toMatchSnapshot();

--- a/src/components/Renderer/__test__/__snapshots__/RendererContent.test.tsx.snap
+++ b/src/components/Renderer/__test__/__snapshots__/RendererContent.test.tsx.snap
@@ -150,11 +150,68 @@ exports[`Test Youtube cover media with sddefault 1`] = `
 </section>
 `;
 
+exports[`Test blockquote with code 1`] = `
+<div
+  className="Pinpoint document"
+>
+  <blockquote>
+    <p>
+      <code
+        spellCheck="false"
+      >
+        GET api/regulations/:id
+      </code>
+    </p>
+  </blockquote>
+</div>
+`;
+
 exports[`Test empty doc 1`] = `
 <div
   className="Pinpoint document"
 >
   <p />
+</div>
+`;
+
+exports[`Test info notice with monospaced font 1`] = `
+<div
+  className="Pinpoint document"
+>
+  <div
+    className="notice info"
+  >
+    <div
+      className="icon"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-info-circle fa-w-16 fa-fw "
+        data-icon="info-circle"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </div>
+    <div>
+      <p>
+        <code
+          spellCheck="false"
+        >
+          This is an info notice with monospaced font
+        </code>
+      </p>
+    </div>
+  </div>
 </div>
 `;
 

--- a/src/components/Renderer/register.tsx
+++ b/src/components/Renderer/register.tsx
@@ -4,7 +4,6 @@ import Break from './br';
 import BulletList from './bullet_list';
 import CodeBlock from './code_block';
 import Emoji from './emoji';
-import Paragraph from './paragraph';
 import File from './file';
 import Heading from './heading';
 import Hr from './hr';
@@ -12,17 +11,18 @@ import Iframe from './iframe';
 import ImageBlock from './image_block';
 import InlineImage from './inline_image';
 import Issue from './issue';
-import LinkedDataListItem from './linked_data_list_item';
 import LinkedDataList from './linked_data_list';
+import LinkedDataListItem from './linked_data_list_item';
 import LinkedDataNode from './linked_data_node';
 import ListItem from './list_item';
 import Notice from './notice';
 import OrderedList from './ordered_list';
+import Paragraph from './paragraph';
 import PullRequest from './pull_request';
+import Table from './table';
 import TableData from './table_data';
 import TableHeader from './table_header';
 import TableRow from './table_row';
-import Table from './table';
 import Text from './text';
 import Toggle from './toggle';
 
@@ -32,7 +32,7 @@ export interface DocOpts {
 
 export interface PmMark {
 	type: string;
-	attrs: Record<string, any>;
+	attrs?: Record<string, any>;
 }
 
 export interface PmNode {

--- a/src/components/Renderer/text.tsx
+++ b/src/components/Renderer/text.tsx
@@ -36,14 +36,14 @@ const Text = ({ node }: NodeProps) => {
 					break;
 				}
 				case 'mark': {
-					const { backgroundColor, color, type } = mark.attrs;
+					const { backgroundColor, color, type } = mark.attrs ?? {};
 					if (type === 'placeholder') {
 						break; // skip placeholders from rendering
 					}
 					const classes: string[] = [];
 
 					if (backgroundColor) {
-						classes.push(`bg-${mark.attrs.backgroundColor}`);
+						classes.push(`bg-${backgroundColor}`);
 					}
 					if (color) {
 						classes.push(color);
@@ -57,7 +57,7 @@ const Text = ({ node }: NodeProps) => {
 					break;
 				}
 				case 'link': {
-					const { href, title = '', id = '' } = mark.attrs;
+					const { href, title = '', id = '' } = mark.attrs ?? {};
 					const hasMarks = (node.marks?.length ?? 0) > 0 && node.marks?.some((m) => !!m.attrs?.color);
 					const className = `${hasMarks ? 'mark-color' : ''}`;
 					content = node._opts?.openLinksInNewWindow ? (
@@ -72,7 +72,7 @@ const Text = ({ node }: NodeProps) => {
 					break;
 				}
 				case 'linked_data': {
-					const { id, type } = mark.attrs;
+					const { id, type } = mark.attrs ?? {};
 					const attrs = {
 						[`data-${type}-id`]: id,
 					};


### PR DESCRIPTION
- Code Blocks inside a notice or blockquote should adapt styles (foreground, background and border) of the parent
- 1.0.28
