### PR TITLE
File of Video type should use the built-in HTML5 Video Player and fallback to the download option if not supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "1.0.28",
+	"version": "1.0.29",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "1.0.28",
+	"version": "1.0.29",
 	"description": "The Pinpoint UI Library for React",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/src/components/Renderer/__data__/video_file.ts
+++ b/src/components/Renderer/__data__/video_file.ts
@@ -1,0 +1,29 @@
+export default {
+	type: 'doc',
+	content: [
+		{
+			type: 'paragraph',
+			content: [
+				{
+					type: 'text',
+					text: 'This is a sample movie',
+				},
+			],
+		},
+		{
+			type: 'file',
+			attrs: {
+				id: 'fzygzf8ves2k',
+				created_ts: 1632502860367,
+				creator_id: 'QgPTcSoYW9Zn7l2bWO4o19r0ffo2',
+				dueDateHasTime: false,
+				completed: false,
+				src: 'https://cdn.pinpoint.com/videos/homepage/Home-Slot-Hero.mp4',
+				filename: 'sample-mov-file.mov',
+				size: 14461898,
+				type: 'video/mp4',
+				publicUrl: 'https://cdn.pinpoint.com/videos/homepage/Home-Slot-Hero.mp4',
+			},
+		},
+	],
+};

--- a/src/components/Renderer/__stories__/Renderer.stories.tsx
+++ b/src/components/Renderer/__stories__/Renderer.stories.tsx
@@ -26,6 +26,7 @@ import simple_ordered_list from '../__data__/simple_ordered_list';
 import simple_paragraph from '../__data__/simple_paragraph';
 import simple_text from '../__data__/simple_text';
 import simple_warning_notice from '../__data__/simple_warning_notice';
+import video_file from '../__data__/video_file';
 
 const { default: readme } = require('../README.md');
 
@@ -119,3 +120,5 @@ export const Youtube_Video: React.VFC<{}> = () => {
 		</Pinpoint>
 	);
 };
+
+export const File_Video: React.VFC<{}> = () => <Document node={video_file} />;

--- a/src/components/Renderer/__test__/RendererContent.test.tsx
+++ b/src/components/Renderer/__test__/RendererContent.test.tsx
@@ -23,6 +23,7 @@ import simple_ordered_list from '../__data__/simple_ordered_list';
 import simple_paragraph from '../__data__/simple_paragraph';
 import simple_text from '../__data__/simple_text';
 import simple_warning_notice from '../__data__/simple_warning_notice';
+import video_file from '../__data__/video_file';
 
 import type { ICoverMedia } from '../../../lib/types/content';
 
@@ -245,6 +246,13 @@ test('Test Youtube cover media with no poster', () => {
 		metadata: {},
 	};
 	const component = renderer.create(<CoverMedia media={youtubeCoverMedia} />);
+	const tree = component.toJSON();
+	expect(tree).toMatchSnapshot();
+});
+
+test('Test file Video', () => {
+	const doc = video_file;
+	const component = renderer.create(<Document node={doc} />);
 	const tree = component.toJSON();
 	expect(tree).toMatchSnapshot();
 });

--- a/src/components/Renderer/__test__/__snapshots__/RendererContent.test.tsx.snap
+++ b/src/components/Renderer/__test__/__snapshots__/RendererContent.test.tsx.snap
@@ -174,6 +174,96 @@ exports[`Test empty doc 1`] = `
 </div>
 `;
 
+exports[`Test file Video 1`] = `
+<div
+  className="Pinpoint document"
+>
+  <p>
+    This is a sample movie
+  </p>
+  <video
+    controls={true}
+    width="100%"
+  >
+    <source
+      src="https://cdn.pinpoint.com/videos/homepage/Home-Slot-Hero.mp4"
+      type="video/mp4"
+    />
+    <div
+      className="file"
+    >
+      <div
+        className="container"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-file-video fa-w-12 "
+          data-icon="file-video"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M384 121.941V128H256V0h6.059c6.365 0 12.47 2.529 16.971 7.029l97.941 97.941A24.005 24.005 0 0 1 384 121.941zM224 136V0H24C10.745 0 0 10.745 0 24v464c0 13.255 10.745 24 24 24h336c13.255 0 24-10.745 24-24V160H248c-13.2 0-24-10.8-24-24zm96 144.016v111.963c0 21.445-25.943 31.998-40.971 16.971L224 353.941V392c0 13.255-10.745 24-24 24H88c-13.255 0-24-10.745-24-24V280c0-13.255 10.745-24 24-24h112c13.255 0 24 10.745 24 24v38.059l55.029-55.013c15.011-15.01 40.971-4.491 40.971 16.97z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <div
+          className="details"
+        >
+          <a
+            className="filename"
+            href="https://cdn.pinpoint.com/videos/homepage/Home-Slot-Hero.mp4"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            sample-mov-file.mov
+          </a>
+          <div
+            className="size"
+          >
+            14.5 MB
+          </div>
+        </div>
+        <div
+          className="options"
+        >
+          <div
+            className="option group"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-download fa-w-16 "
+              data-icon="download"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            <span>
+              Download
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </video>
+</div>
+`;
+
 exports[`Test info notice with monospaced font 1`] = `
 <div
   className="Pinpoint document"

--- a/src/components/Renderer/file.tsx
+++ b/src/components/Renderer/file.tsx
@@ -1,19 +1,10 @@
+import React from 'react'; // don't remove
 import {
-	faDownload,
-	faFile,
-	faFileAlt,
-	faFileArchive,
-	faFileAudio,
-	faFileCode,
-	faFileExcel,
-	faFilePdf,
-	faFilePowerpoint,
-	faFileVideo,
-	faFileWord,
+	faDownload, faFile, faFileAlt, faFileArchive, faFileAudio, faFileCode, faFileExcel, faFilePdf,
+	faFilePowerpoint, faFileVideo, faFileWord
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { NodeProps } from './register';
-import React from 'react';
 
 export const iconForType = (type = '') => {
 	if (/pdf/.test(type)) {
@@ -58,9 +49,18 @@ export const formattedSize = (size = 0) => {
 	return `${Math.round(MB * 10) / 10} MB`;
 };
 
-const File = ({ node }: NodeProps) => {
-	const { description, filename, size, src, type } = node.attrs;
+const VideoFile = ({ node }: NodeProps) => {
+	const { src, type } = node.attrs;
+	return (
+		<video controls width="100%">
+			<source src={src} type={type} />
+			<DownloadFile node={node} />
+		</video>
+	);
+};
 
+const DownloadFile = ({ node }: NodeProps) => {
+	const { description, filename, size, src, type } = node.attrs;
 	const onDownload = () => {
 		if (src) {
 			const u = new URL(src);
@@ -103,6 +103,15 @@ const File = ({ node }: NodeProps) => {
 			</div>
 		</div>
 	);
+};
+
+const File = ({ node }: NodeProps) => {
+	const { type } = node.attrs;
+
+	if (type.startsWith('video/')) {
+		return <VideoFile node={node} />;
+	}
+	return <DownloadFile node={node} />;
 };
 
 export default File;


### PR DESCRIPTION
- File of Video type should use the built-in HTML5 Video Player and fallback to the download option if not supported
- 1.0.29
