### PR TITLE
Feedback Widget Dark mode fixes, Theme detection fix, Image zoom fix

### DIFF
--- a/base.css
+++ b/base.css
@@ -832,61 +832,14 @@ html.dark .Pinpoint.ThemeToggle .mode::after {
 	@apply h-[19rem] sm:h-[27rem] md:h-[32rem] lg:h-[36rem];
 }
 
-.Pinpoint.feedbackWrapper {
-	@apply mt-10 mb-5 border rounded p-4 inline-flex bg-white shadow-lg;
+/* styles from medium zoom image */
+.medium-zoom-overlay,
+.medium-zoom-image--opened {
+	@apply z-[5000];
 }
 
-/* styles from medium zoom image */
-[data-rmiz-wrap='visible'],
-[data-rmiz-wrap='hidden'] {
-	position: relative;
-	display: inline-flex;
-	align-items: flex-start;
-}
-[data-rmiz-wrap='hidden'] {
-	visibility: hidden;
-}
-[data-rmiz-overlay] {
-	position: fixed;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	transition-property: background-color;
-}
-[data-rmiz-btn-open],
-[data-rmiz-btn-close] {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	margin: 0;
-	padding: 0;
-	border: none;
-	border-radius: 0;
-	font: inherit;
-	color: inherit;
-	background: none;
-	-webkit-appearance: none;
-	-moz-appearance: none;
-	appearance: none;
-}
-[data-rmiz-btn-open] {
-	cursor: zoom-in;
-}
-[data-rmiz-btn-close] {
-	cursor: zoom-out;
-}
-[data-rmiz-modal-content] {
-	position: absolute;
-	transition-property: transform;
-	transform-origin: center center;
-}
-[data-rmiz-wrap='visible'] > button {
-	cursor: zoom-in;
+@media (prefers-reduced-motion: reduce) {
+	.medium-zoom-image {
+		transition: transform 1ms !important;
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8097,11 +8097,6 @@
 				}
 			}
 		},
-		"@types/js-cookie": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
-			"integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
-		},
 		"@types/json-schema": {
 			"version": "7.0.8",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
@@ -8626,11 +8621,6 @@
 				"@webassemblyjs/wast-parser": "1.9.0",
 				"@xtuc/long": "4.2.2"
 			}
-		},
-		"@xobotyi/scrollbar-width": {
-			"version": "1.9.5",
-			"resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
-			"integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -10642,6 +10632,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
 			"integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+			"dev": true,
 			"requires": {
 				"toggle-selection": "^1.0.6"
 			}
@@ -11046,22 +11037,6 @@
 			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
 			"dev": true
 		},
-		"css-in-js-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-			"integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-			"requires": {
-				"hyphenate-style-name": "^1.0.2",
-				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
-		},
 		"css-loader": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -11166,22 +11141,6 @@
 				"nth-check": "^2.0.0"
 			}
 		},
-		"css-tree": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-			"requires": {
-				"mdn-data": "2.0.14",
-				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
 		"css-unit-converter": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
@@ -11226,7 +11185,8 @@
 		"csstype": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-			"integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+			"integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
+			"dev": true
 		},
 		"cyclist": {
 			"version": "1.0.1",
@@ -11800,6 +11760,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
 			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+			"dev": true,
 			"requires": {
 				"stackframe": "^1.1.1"
 			}
@@ -12264,7 +12225,8 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "3.2.7",
@@ -12296,16 +12258,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
-		},
-		"fast-shallow-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-			"integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
-		},
-		"fastest-stable-stringify": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
-			"integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
 		},
 		"fastq": {
 			"version": "1.11.1",
@@ -12564,11 +12516,6 @@
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.3.6"
 			}
-		},
-		"focus-options-polyfill": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/focus-options-polyfill/-/focus-options-polyfill-1.2.0.tgz",
-			"integrity": "sha512-4sgXxV/zU4WHM2IHWpjUmEWazbF6ie+M93/uo8ipfAbQ1GHopn+/V+Ca+PR0ndxswNQbisCNrjbnvWEq14MkTA=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -13622,11 +13569,6 @@
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true
 		},
-		"hyphenate-style-name": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-			"integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -13816,14 +13758,6 @@
 			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
 			"integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
 			"dev": true
-		},
-		"inline-style-prefixer": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
-			"integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
-			"requires": {
-				"css-in-js-utils": "^2.0.0"
-			}
 		},
 		"internal-slot": {
 			"version": "1.0.3",
@@ -14918,11 +14852,6 @@
 				}
 			}
 		},
-		"js-cookie": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
-		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -15310,11 +15239,6 @@
 			"integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
 			"dev": true
 		},
-		"mdn-data": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
-		},
 		"mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -15326,6 +15250,11 @@
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
+		},
+		"medium-zoom": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
+			"integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg=="
 		},
 		"memfs": {
 			"version": "3.2.4",
@@ -15624,21 +15553,6 @@
 			"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
 			"dev": true,
 			"optional": true
-		},
-		"nano-css": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.4.tgz",
-			"integrity": "sha512-wfcviJB6NOxDIDfr7RFn/GlaN7I/Bhe4d39ZRCJ3xvZX60LVe2qZ+rDqM49nm4YT81gAjzS+ZklhKP/Gnfnubg==",
-			"requires": {
-				"css-tree": "^1.1.2",
-				"csstype": "^3.0.6",
-				"fastest-stable-stringify": "^2.0.2",
-				"inline-style-prefixer": "^6.0.0",
-				"rtl-css-js": "^1.14.0",
-				"sourcemap-codec": "^1.4.8",
-				"stacktrace-js": "^2.0.2",
-				"stylis": "^4.0.6"
-			}
 		},
 		"nanoid": {
 			"version": "3.1.23",
@@ -17448,16 +17362,6 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
 			"dev": true
 		},
-		"react-medium-image-zoom": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/react-medium-image-zoom/-/react-medium-image-zoom-4.3.5.tgz",
-			"integrity": "sha512-feYHG+8McStfQ+mvFJTlmD1GQaYWiVlMf/Rv1MSRcd6UBBj+X8yj5OySw/Xau5PYFPCms7FbpCkt6437iRW47w==",
-			"requires": {
-				"focus-options-polyfill": "1.2.0",
-				"react-use": "^17.2.1",
-				"tslib": "^2.1.0"
-			}
-		},
 		"react-popper": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
@@ -17548,32 +17452,6 @@
 				"@babel/runtime": "^7.10.2",
 				"use-composed-ref": "^1.0.0",
 				"use-latest": "^1.0.0"
-			}
-		},
-		"react-universal-interface": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-			"integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
-		},
-		"react-use": {
-			"version": "17.3.1",
-			"resolved": "https://registry.npmjs.org/react-use/-/react-use-17.3.1.tgz",
-			"integrity": "sha512-hs7+tS4rRm1QLHPfanLCqXIi632tP4V7Sai1ENUP2WTufU6am++tU9uSw9YrNCFqbABiEv0ndKU1XCUcfu2tXA==",
-			"requires": {
-				"@types/js-cookie": "^2.2.6",
-				"@xobotyi/scrollbar-width": "^1.9.5",
-				"copy-to-clipboard": "^3.3.1",
-				"fast-deep-equal": "^3.1.3",
-				"fast-shallow-equal": "^1.0.0",
-				"js-cookie": "^2.2.1",
-				"nano-css": "^5.3.1",
-				"react-universal-interface": "^0.6.2",
-				"resize-observer-polyfill": "^1.5.1",
-				"screenfull": "^5.1.0",
-				"set-harmonic-interval": "^1.0.1",
-				"throttle-debounce": "^3.0.1",
-				"ts-easing": "^0.2.0",
-				"tslib": "^2.1.0"
 			}
 		},
 		"read-pkg": {
@@ -17959,11 +17837,6 @@
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
-		"resize-observer-polyfill": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-		},
 		"resolve": {
 			"version": "1.20.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -18136,14 +18009,6 @@
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
 			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
 			"dev": true
-		},
-		"rtl-css-js": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.14.2.tgz",
-			"integrity": "sha512-t6Wc/wpqm8s3kuXAV6tL/T7VS6n0XszzX58CgCsLj3O2xi9ITSLfzYhtl+GKyxCi/3QEqVctOJQwCiDzb2vteQ==",
-			"requires": {
-				"@babel/runtime": "^7.1.2"
-			}
 		},
 		"run-parallel": {
 			"version": "1.2.0",
@@ -18449,11 +18314,6 @@
 				"ajv-keywords": "^3.5.2"
 			}
 		},
-		"screenfull": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.1.0.tgz",
-			"integrity": "sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA=="
-		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -18559,11 +18419,6 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
-		},
-		"set-harmonic-interval": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
-			"integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -18903,7 +18758,8 @@
 		"sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
 		},
 		"space-separated-tokens": {
 			"version": "1.1.5",
@@ -18972,14 +18828,6 @@
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
 			"dev": true
 		},
-		"stack-generator": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-			"integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
-			"requires": {
-				"stackframe": "^1.1.1"
-			}
-		},
 		"stack-utils": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -19000,33 +18848,8 @@
 		"stackframe": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
-		},
-		"stacktrace-gps": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
-			"integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
-			"requires": {
-				"source-map": "0.5.6",
-				"stackframe": "^1.1.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.6",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-					"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-				}
-			}
-		},
-		"stacktrace-js": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
-			"integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
-			"requires": {
-				"error-stack-parser": "^2.0.6",
-				"stack-generator": "^2.0.5",
-				"stacktrace-gps": "^3.0.4"
-			}
+			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+			"dev": true
 		},
 		"state-toggle": {
 			"version": "1.0.3",
@@ -19261,11 +19084,6 @@
 			"requires": {
 				"inline-style-parser": "0.1.1"
 			}
-		},
-		"stylis": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
-			"integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -19648,7 +19466,8 @@
 		"throttle-debounce": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
-			"integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
+			"integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+			"dev": true
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -19740,7 +19559,8 @@
 		"toggle-selection": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
+			"dev": true
 		},
 		"toidentifier": {
 			"version": "1.0.0",
@@ -19791,11 +19611,6 @@
 			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
 			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
 			"dev": true
-		},
-		"ts-easing": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
-			"integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
 		},
 		"ts-essentials": {
 			"version": "2.0.12",
@@ -19862,7 +19677,8 @@
 		"tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"dev": true
 		},
 		"tty-browserify": {
 			"version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"debug": "^4.3.2",
 		"isomorphic-unfetch": "^3.1.0",
 		"luxon": "^2.0.2",
-		"react-medium-image-zoom": "^4.3.5",
+		"medium-zoom": "^1.0.6",
 		"react-syntax-highlighter": "^15.4.4",
 		"slugify": "^1.6.0"
 	},

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -13,7 +13,9 @@ module.exports = {
 					selector.startsWith(prefix) ||
 					selector.charAt(0) === ':' ||
 					selector.startsWith('.dark') ||
-					selector.startsWith('html.dark') ||
+					selector.startsWith('html') ||
+					selector.startsWith('body') ||
+					selector.startsWith('.medium-zoom') ||
 					selector.charAt(0) === '['
 				) {
 					return selector;

--- a/src/components/Author/__test__/__snapshots__/Author.test.tsx.snap
+++ b/src/components/Author/__test__/__snapshots__/Author.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Test custom className 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image avatar "
+      className="Pinpoint Image avatar"
       decoding="async"
       height={48}
       loading="lazy"
@@ -36,7 +36,7 @@ exports[`Test default 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image avatar "
+      className="Pinpoint Image avatar"
       decoding="async"
       height={48}
       loading="lazy"
@@ -62,7 +62,7 @@ exports[`Test no name 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image avatar "
+      className="Pinpoint Image avatar"
       decoding="async"
       height={48}
       loading="lazy"

--- a/src/components/Card/__test__/__snapshots__/CardContainer.test.tsx.snap
+++ b/src/components/Card/__test__/__snapshots__/CardContainer.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Test full card 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image cover "
+    className="Pinpoint Image cover"
     decoding="async"
     loading="lazy"
     src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -208,7 +208,7 @@ exports[`Test full card with custom class 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image cover "
+    className="Pinpoint Image cover"
     decoding="async"
     loading="lazy"
     src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -358,7 +358,7 @@ exports[`Test multiple cards 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image cover "
+      className="Pinpoint Image cover"
       decoding="async"
       loading="lazy"
       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -529,7 +529,7 @@ exports[`Test multiple cards 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image cover "
+      className="Pinpoint Image cover"
       decoding="async"
       loading="lazy"
       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -704,7 +704,7 @@ exports[`Test no description 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image cover "
+    className="Pinpoint Image cover"
     decoding="async"
     loading="lazy"
     src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -979,7 +979,7 @@ exports[`Test no statistics 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image cover "
+    className="Pinpoint Image cover"
     decoding="async"
     loading="lazy"
     src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1010,7 +1010,7 @@ exports[`Test no title 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image cover "
+    className="Pinpoint Image cover"
     decoding="async"
     loading="lazy"
     src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="

--- a/src/components/Copyright/__test__/__snapshots__/Copyright.test.tsx.snap
+++ b/src/components/Copyright/__test__/__snapshots__/Copyright.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Test with clickable logo 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"
@@ -37,7 +37,7 @@ exports[`Test with custom className 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"
@@ -65,7 +65,7 @@ exports[`Test with linked logo 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"
@@ -91,7 +91,7 @@ exports[`Test with logo 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"

--- a/src/components/Documentation/Page/__test__/__snapshots__/DocumentationHome.test.tsx.snap
+++ b/src/components/Documentation/Page/__test__/__snapshots__/DocumentationHome.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`Test full page 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -563,7 +563,7 @@ exports[`Test loading 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1211,7 +1211,7 @@ exports[`Test no header 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1727,7 +1727,7 @@ exports[`Test with search SocialMediaBar 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -2269,7 +2269,7 @@ exports[`With pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Documentation/Page/__test__/__snapshots__/DocumentationSearchResults.test.tsx.snap
+++ b/src/components/Documentation/Page/__test__/__snapshots__/DocumentationSearchResults.test.tsx.snap
@@ -181,7 +181,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Documentation/Prebuilt/__test__/__snapshots__/PrebuiltDocumentationHome.test.tsx.snap
+++ b/src/components/Documentation/Prebuilt/__test__/__snapshots__/PrebuiltDocumentationHome.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Test custom className 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -325,7 +325,7 @@ exports[`Test custom className 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image  "
+                      className="Pinpoint Image"
                       decoding="async"
                       height={509.6}
                       loading="lazy"
@@ -380,7 +380,7 @@ exports[`Test custom className 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image  "
+                      className="Pinpoint Image"
                       decoding="async"
                       height={360}
                       loading="lazy"
@@ -458,7 +458,7 @@ exports[`Test custom className 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -745,7 +745,7 @@ exports[`Test custom metadata 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1015,7 +1015,7 @@ exports[`Test custom metadata 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image  "
+                      className="Pinpoint Image"
                       decoding="async"
                       height={509.6}
                       loading="lazy"
@@ -1070,7 +1070,7 @@ exports[`Test custom metadata 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image  "
+                      className="Pinpoint Image"
                       decoding="async"
                       height={360}
                       loading="lazy"
@@ -1148,7 +1148,7 @@ exports[`Test custom metadata 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1435,7 +1435,7 @@ exports[`Test default state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1705,7 +1705,7 @@ exports[`Test default state 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image  "
+                      className="Pinpoint Image"
                       decoding="async"
                       height={509.6}
                       loading="lazy"
@@ -1760,7 +1760,7 @@ exports[`Test default state 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image  "
+                      className="Pinpoint Image"
                       decoding="async"
                       height={360}
                       loading="lazy"
@@ -1838,7 +1838,7 @@ exports[`Test default state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -2125,7 +2125,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -2395,7 +2395,7 @@ exports[`Test with pagination 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image  "
+                      className="Pinpoint Image"
                       decoding="async"
                       height={540}
                       loading="lazy"
@@ -2520,7 +2520,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Documentation/Prebuilt/__test__/__snapshots__/PrebuiltDocumentationSearchResults.test.tsx.snap
+++ b/src/components/Documentation/Prebuilt/__test__/__snapshots__/PrebuiltDocumentationSearchResults.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Test custom className 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -314,7 +314,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -601,7 +601,7 @@ exports[`Test default state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -860,7 +860,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1147,7 +1147,7 @@ exports[`Test empty state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1314,7 +1314,7 @@ exports[`Test empty state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1601,7 +1601,7 @@ exports[`Test loading state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1683,7 +1683,7 @@ exports[`Test loading state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Documentation/Title/__test__/__snapshots__/Title.test.tsx.snap
+++ b/src/components/Documentation/Title/__test__/__snapshots__/Title.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Test click handler 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"
@@ -37,7 +37,7 @@ exports[`Test custom className 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"
@@ -63,7 +63,7 @@ exports[`Test custom text 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"
@@ -89,7 +89,7 @@ exports[`Test default state 1`] = `
   >
     <img
       alt=""
-      className="Pinpoint Image image "
+      className="Pinpoint Image image"
       decoding="async"
       height={320}
       loading="lazy"

--- a/src/components/Footer/__test__/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/Footer/__test__/__snapshots__/Footer.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Test complete 1`] = `
         >
           <img
             alt=""
-            className="Pinpoint Image image "
+            className="Pinpoint Image image"
             decoding="async"
             height={320}
             loading="lazy"
@@ -294,7 +294,7 @@ exports[`Test no custom class 1`] = `
         >
           <img
             alt=""
-            className="Pinpoint Image image "
+            className="Pinpoint Image image"
             decoding="async"
             height={320}
             loading="lazy"
@@ -387,7 +387,7 @@ exports[`Test no social 1`] = `
         >
           <img
             alt=""
-            className="Pinpoint Image image "
+            className="Pinpoint Image image"
             decoding="async"
             height={320}
             loading="lazy"
@@ -508,7 +508,7 @@ exports[`Test no subscribe 1`] = `
         >
           <img
             alt=""
-            className="Pinpoint Image image "
+            className="Pinpoint Image image"
             decoding="async"
             height={320}
             loading="lazy"

--- a/src/components/Head/__test__/__snapshots__/Head.test.tsx.snap
+++ b/src/components/Head/__test__/__snapshots__/Head.test.tsx.snap
@@ -22,6 +22,13 @@ Array [
     name="viewport"
   />,
   <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "(()=>{const element=document.documentElement;const localTheme=window.localStorage.getItem('theme');if(localTheme==='dark'){element.classList.add('dark');}})();",
+      }
+    }
+  />,
+  <script
     data-base-path="/"
     data-id="oroH8YQr4vufOiVTRND4"
     data-site-id="PirxVTE94u3YmGNOySRY"
@@ -163,6 +170,13 @@ Array [
     name="viewport"
   />,
   <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "(()=>{const element=document.documentElement;const localTheme=window.localStorage.getItem('theme');if(localTheme==='dark'){element.classList.add('dark');}})();",
+      }
+    }
+  />,
+  <script
     data-base-path="/"
     data-site-id="PirxVTE94u3YmGNOySRY"
     data-use-react={true}
@@ -267,6 +281,13 @@ Array [
   <meta
     content="width=device-width"
     name="viewport"
+  />,
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "(()=>{const element=document.documentElement;const localTheme=window.localStorage.getItem('theme');if(localTheme==='dark'){element.classList.add('dark');}})();",
+      }
+    }
   />,
   <script
     data-base-path="/blog"

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -10,6 +10,29 @@ export interface IHeadProps {
 	children?: React.ReactChild;
 }
 
+const functionToString = (func: Function) => {
+	// poormans minify
+	return func
+		.toString()
+		.replace(/[\n\t]/g, '')
+		.replace(/[\s]{2,}/g, ' ')
+		.replace(/;\s/g, ';')
+		.replace(/if\s\(/g, 'if(')
+		.replace(/\s{\s/g, '{')
+		.replace(/\s}\s/g, '}')
+		.replace(/}\s/g, '}')
+		.replace(/=\s/g, '=')
+		.replace(/\s=/g, '=');
+};
+
+const InlineScript = ({ children }: { children: Function }) => (
+	<script
+		dangerouslySetInnerHTML={{
+			__html: `(${functionToString(children)})();`,
+		}}
+	/> // eslint-disable-line
+);
+
 const Head = (props: IHeadProps) => {
 	const { site, content, children } = props;
 	return (
@@ -19,6 +42,16 @@ const Head = (props: IHeadProps) => {
 			<link rel="preconnect" href="https://file.pinpoint.com" />
 			<meta httpEquiv="x-ua-compatible" content="ie=edge" />
 			<meta name="viewport" content="width=device-width" />
+			{/* Set the theme while parsing so that we dont have a flash for the theme */}
+			<InlineScript>
+				{() => {
+					const element = document.documentElement;
+					const localTheme = window.localStorage.getItem('theme');
+					if (localTheme === 'dark') {
+						element.classList.add('dark');
+					}
+				}}
+			</InlineScript>
 			<script
 				src={getSiteAnalyticsURL(site)}
 				data-site-id={site.id}

--- a/src/components/Image/__stories__/Image.stories.tsx
+++ b/src/components/Image/__stories__/Image.stories.tsx
@@ -30,3 +30,14 @@ export const BlurHash: React.VFC<{}> = () => (
 		alt="blurhash"
 	/>
 );
+
+export const Zoomable: React.VFC<{}> = () => (
+	<div className="flex flex-row gap-10">
+		<Image src="https://via.placeholder.com/150" width={150} height={150} zoomable />
+		<Image src="https://via.placeholder.com/150" width={150} height={150} zoomable />
+		<Image src="https://via.placeholder.com/150" width={150} height={150} zoomable />
+		<Image src="https://via.placeholder.com/150" width={150} height={150} zoomable />
+		<Image src="https://via.placeholder.com/150" width={150} height={150} zoomable />
+		<Image src="https://via.placeholder.com/150" width={150} height={150} zoomable />
+	</div>
+);

--- a/src/components/Image/__test__/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__test__/__snapshots__/Image.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Test with alt 1`] = `
 <img
   alt="150x150 placeholder"
-  className="Pinpoint Image  "
+  className="Pinpoint Image"
   decoding="async"
   loading="lazy"
   src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -13,7 +13,7 @@ exports[`Test with alt 1`] = `
 exports[`Test with blurhash 1`] = `
 <img
   alt="blurhash"
-  className="Pinpoint Image  "
+  className="Pinpoint Image"
   decoding="async"
   height={860}
   loading="lazy"
@@ -25,7 +25,7 @@ exports[`Test with blurhash 1`] = `
 exports[`Test with className 1`] = `
 <img
   alt="150x150 placeholder"
-  className="Pinpoint Image placeholder "
+  className="Pinpoint Image placeholder"
   decoding="async"
   loading="lazy"
   src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -37,7 +37,7 @@ exports[`Test with no source 1`] = `null`;
 exports[`Test with no width or height 1`] = `
 <img
   alt=""
-  className="Pinpoint Image  "
+  className="Pinpoint Image"
   decoding="async"
   loading="lazy"
   src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -47,7 +47,7 @@ exports[`Test with no width or height 1`] = `
 exports[`Test with width and height 1`] = `
 <img
   alt=""
-  className="Pinpoint Image  "
+  className="Pinpoint Image"
   decoding="async"
   height={150}
   loading="lazy"

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,4 +1,5 @@
 import { decode } from 'blurhash';
+import mediumZoom from 'medium-zoom';
 import React from 'react'; // don't remove
 import { extractImageMetadataFromFileID, isFileAPI } from '../../lib/file_metadata';
 
@@ -27,11 +28,12 @@ interface ImageProps {
 	sizes?: string;
 	blurhash?: string;
 	lazy?: boolean;
+	zoomable?: boolean;
 }
 
 const NativeImage = (props: ImageProps) => {
 	const ref = React.useRef<any>();
-	const { src, alt = '', width, height, className = '', srcSet, sizes, blurhash, lazy = true } = props;
+	const { src, alt = '', width, height, className = '', srcSet, sizes, blurhash, zoomable, lazy = true } = props;
 	const [ready, setReady] = React.useState(!lazy);
 	React.useEffect(() => {
 		if (src && ref.current && lazy) {
@@ -67,6 +69,7 @@ const NativeImage = (props: ImageProps) => {
 			ready={ready}
 			blurhash={blurhash}
 			lazy={lazy}
+			zoomable={zoomable}
 		/>
 	);
 };
@@ -96,12 +99,24 @@ const BlurImage = React.forwardRef<any, BlurImageProps>((props: BlurImageProps, 
 		src = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 		// show a 1x1 transparent pixel while loading if no blurhash
 	}
+	const { zoomable, src: _src, ready } = props;
+	React.useEffect(() => {
+		if (zoomable && typeof window !== 'undefined' && !isBlurhash && _src && ready) {
+			const el = (ref as any).current as any;
+			const zoom = mediumZoom(el);
+			return () => {
+				zoom.detach();
+			};
+		}
+	}, [zoomable, _src, ready]);
 	return (
 		<img
 			ref={ref}
 			src={src}
 			alt={props.alt ?? ''}
-			className={`Pinpoint Image ${props.className ?? ''} ${isBlurhash ? 'blurhash' : ''}`}
+			className={`Pinpoint Image ${props.className ?? ''} ${isBlurhash ? 'blurhash' : ''} ${
+				zoomable && !isBlurhash && ready && _src ? 'medium-zoom-body' : ''
+			}`.trim()}
 			width={props.width ?? r.size?.width}
 			height={props.height ?? r.size?.height}
 			decoding="async"
@@ -157,6 +172,7 @@ const DynamicImage = (props: ImageProps) => {
 			height={props.height}
 			blurhash={props.blurhash}
 			ready={loaded}
+			zoomable={props.zoomable}
 		/>
 	);
 };

--- a/src/components/Latest/__test__/__snapshots__/Latest.test.tsx.snap
+++ b/src/components/Latest/__test__/__snapshots__/Latest.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Test custom className 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -204,7 +204,7 @@ exports[`Test double 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -375,7 +375,7 @@ exports[`Test double 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -564,7 +564,7 @@ exports[`Test single 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -751,7 +751,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -922,7 +922,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1093,7 +1093,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="

--- a/src/components/Logo/__test__/__snapshots__/Logo.test.tsx.snap
+++ b/src/components/Logo/__test__/__snapshots__/Logo.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Test click handler 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -27,7 +27,7 @@ exports[`Test click handler and link 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -44,7 +44,7 @@ exports[`Test default state 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -61,7 +61,7 @@ exports[`Test extra large 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -78,7 +78,7 @@ exports[`Test extra small 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -95,7 +95,7 @@ exports[`Test large 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -116,7 +116,7 @@ exports[`Test link (new tab) 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -135,7 +135,7 @@ exports[`Test link 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -152,7 +152,7 @@ exports[`Test medium 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"
@@ -169,7 +169,7 @@ exports[`Test small 1`] = `
 >
   <img
     alt=""
-    className="Pinpoint Image image "
+    className="Pinpoint Image image"
     decoding="async"
     height={320}
     loading="lazy"

--- a/src/components/Page/__test__/__snapshots__/PageDashboard.test.tsx.snap
+++ b/src/components/Page/__test__/__snapshots__/PageDashboard.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`Test full page 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -268,7 +268,7 @@ exports[`Test full page 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -461,7 +461,7 @@ exports[`Test full page 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -632,7 +632,7 @@ exports[`Test full page 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -803,7 +803,7 @@ exports[`Test full page 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -974,7 +974,7 @@ exports[`Test full page 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1168,7 +1168,7 @@ exports[`Test full page 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1537,7 +1537,7 @@ exports[`Test loading 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1822,7 +1822,7 @@ exports[`Test no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1993,7 +1993,7 @@ exports[`Test no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -2186,7 +2186,7 @@ exports[`Test no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -2357,7 +2357,7 @@ exports[`Test no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -2528,7 +2528,7 @@ exports[`Test no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -2699,7 +2699,7 @@ exports[`Test no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -2898,7 +2898,7 @@ exports[`Test no header 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3069,7 +3069,7 @@ exports[`Test no header 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3262,7 +3262,7 @@ exports[`Test no header 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3433,7 +3433,7 @@ exports[`Test no header 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3604,7 +3604,7 @@ exports[`Test no header 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3775,7 +3775,7 @@ exports[`Test no header 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3969,7 +3969,7 @@ exports[`Test no header 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -4255,7 +4255,7 @@ exports[`Test no latest 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -4426,7 +4426,7 @@ exports[`Test no latest 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -4597,7 +4597,7 @@ exports[`Test no latest 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -4768,7 +4768,7 @@ exports[`Test no latest 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -4962,7 +4962,7 @@ exports[`Test no latest 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -5247,7 +5247,7 @@ exports[`Test no recent 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -5418,7 +5418,7 @@ exports[`Test no recent 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image cover "
+              className="Pinpoint Image cover"
               decoding="async"
               loading="lazy"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -5612,7 +5612,7 @@ exports[`Test no recent 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Page/__test__/__snapshots__/PageEntry.test.tsx.snap
+++ b/src/components/Page/__test__/__snapshots__/PageEntry.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Test full entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -256,7 +256,7 @@ exports[`Test full entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -316,7 +316,7 @@ exports[`Test full entry 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -371,7 +371,7 @@ exports[`Test full entry 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -436,7 +436,7 @@ exports[`Test full entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -603,7 +603,7 @@ exports[`Test full entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -961,7 +961,7 @@ exports[`Test no footer 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -1113,7 +1113,7 @@ exports[`Test no footer 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -1173,7 +1173,7 @@ exports[`Test no footer 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -1228,7 +1228,7 @@ exports[`Test no footer 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -1288,7 +1288,7 @@ exports[`Test no footer 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -1533,7 +1533,7 @@ exports[`Test no sidebar 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -1593,7 +1593,7 @@ exports[`Test no sidebar 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -1648,7 +1648,7 @@ exports[`Test no sidebar 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -1723,7 +1723,7 @@ exports[`Test no sidebar 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -2086,7 +2086,7 @@ exports[`Test not zoomable entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -2238,7 +2238,7 @@ exports[`Test not zoomable entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -2298,7 +2298,7 @@ exports[`Test not zoomable entry 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -2353,7 +2353,7 @@ exports[`Test not zoomable entry 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -2418,7 +2418,7 @@ exports[`Test not zoomable entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -2585,7 +2585,7 @@ exports[`Test not zoomable entry 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -2948,7 +2948,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -3100,7 +3100,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -3160,7 +3160,7 @@ exports[`Test with pagination 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -3215,7 +3215,7 @@ exports[`Test with pagination 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -3280,7 +3280,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={48}
                   loading="lazy"
@@ -3513,7 +3513,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Page/__test__/__snapshots__/PageError.test.tsx.snap
+++ b/src/components/Page/__test__/__snapshots__/PageError.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Test full error 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Prebuilt/__test__/__snapshots__/PrebuiltEntry.test.tsx.snap
+++ b/src/components/Prebuilt/__test__/__snapshots__/PrebuiltEntry.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Test custom className 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -165,7 +165,7 @@ exports[`Test custom className 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -409,7 +409,7 @@ exports[`Test custom className 1`] = `
               >
                 <img
                   alt="Linked Content Blocks"
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -469,7 +469,7 @@ exports[`Test custom className 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -524,7 +524,7 @@ exports[`Test custom className 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -641,7 +641,7 @@ exports[`Test custom className 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -902,7 +902,7 @@ exports[`Test custom className 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1188,7 +1188,7 @@ exports[`Test default state 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -1326,7 +1326,7 @@ exports[`Test default state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -1570,7 +1570,7 @@ exports[`Test default state 1`] = `
               >
                 <img
                   alt="Linked Content Blocks"
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -1630,7 +1630,7 @@ exports[`Test default state 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -1685,7 +1685,7 @@ exports[`Test default state 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -1802,7 +1802,7 @@ exports[`Test default state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -2063,7 +2063,7 @@ exports[`Test default state 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -2349,7 +2349,7 @@ exports[`Test no author 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -2624,7 +2624,7 @@ exports[`Test no author 1`] = `
               >
                 <img
                   alt="Linked Content Blocks"
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -2684,7 +2684,7 @@ exports[`Test no author 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -2739,7 +2739,7 @@ exports[`Test no author 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -3010,7 +3010,7 @@ exports[`Test no author 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -3296,7 +3296,7 @@ exports[`Test no authors 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -3585,7 +3585,7 @@ exports[`Test no authors 1`] = `
               >
                 <img
                   alt="Analytics Drilldown + Changelog Generator Styling"
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={1666}
                   loading="eager"
@@ -3680,7 +3680,7 @@ exports[`Test no authors 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image thumbnail "
+                      className="Pinpoint Image thumbnail"
                       decoding="async"
                       loading="lazy"
                       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3693,7 +3693,7 @@ exports[`Test no authors 1`] = `
                       >
                         <img
                           alt=""
-                          className="Pinpoint Image icon "
+                          className="Pinpoint Image icon"
                           decoding="async"
                           loading="lazy"
                           src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3774,7 +3774,7 @@ exports[`Test no authors 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={468.65}
                     loading="lazy"
@@ -3862,7 +3862,7 @@ exports[`Test no authors 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image thumbnail "
+                      className="Pinpoint Image thumbnail"
                       decoding="async"
                       loading="lazy"
                       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3875,7 +3875,7 @@ exports[`Test no authors 1`] = `
                       >
                         <img
                           alt=""
-                          className="Pinpoint Image icon "
+                          className="Pinpoint Image icon"
                           decoding="async"
                           loading="lazy"
                           src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3930,7 +3930,7 @@ exports[`Test no authors 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image thumbnail "
+                      className="Pinpoint Image thumbnail"
                       decoding="async"
                       loading="lazy"
                       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3943,7 +3943,7 @@ exports[`Test no authors 1`] = `
                       >
                         <img
                           alt=""
-                          className="Pinpoint Image icon "
+                          className="Pinpoint Image icon"
                           decoding="async"
                           loading="lazy"
                           src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3984,7 +3984,7 @@ exports[`Test no authors 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image thumbnail "
+                      className="Pinpoint Image thumbnail"
                       decoding="async"
                       loading="lazy"
                       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -3997,7 +3997,7 @@ exports[`Test no authors 1`] = `
                       >
                         <img
                           alt=""
-                          className="Pinpoint Image icon "
+                          className="Pinpoint Image icon"
                           decoding="async"
                           loading="lazy"
                           src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -4087,7 +4087,7 @@ exports[`Test no authors 1`] = `
                   >
                     <img
                       alt=""
-                      className="Pinpoint Image thumbnail "
+                      className="Pinpoint Image thumbnail"
                       decoding="async"
                       loading="lazy"
                       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -4100,7 +4100,7 @@ exports[`Test no authors 1`] = `
                       >
                         <img
                           alt=""
-                          className="Pinpoint Image icon "
+                          className="Pinpoint Image icon"
                           decoding="async"
                           loading="lazy"
                           src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -4372,7 +4372,7 @@ exports[`Test no authors 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -4658,7 +4658,7 @@ exports[`Test no claps 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -4796,7 +4796,7 @@ exports[`Test no claps 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -4956,7 +4956,7 @@ exports[`Test no claps 1`] = `
               >
                 <img
                   alt="Linked Content Blocks"
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -5016,7 +5016,7 @@ exports[`Test no claps 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -5071,7 +5071,7 @@ exports[`Test no claps 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -5188,7 +5188,7 @@ exports[`Test no claps 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -5365,7 +5365,7 @@ exports[`Test no claps 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -5651,7 +5651,7 @@ exports[`Test not zoomable 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -5789,7 +5789,7 @@ exports[`Test not zoomable 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -6033,7 +6033,7 @@ exports[`Test not zoomable 1`] = `
               >
                 <img
                   alt="Linked Content Blocks"
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -6093,7 +6093,7 @@ exports[`Test not zoomable 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={509.6}
                     loading="lazy"
@@ -6148,7 +6148,7 @@ exports[`Test not zoomable 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={360}
                     loading="lazy"
@@ -6265,7 +6265,7 @@ exports[`Test not zoomable 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -6526,7 +6526,7 @@ exports[`Test not zoomable 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -6812,7 +6812,7 @@ exports[`Test with pagination 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -6950,7 +6950,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -7097,7 +7097,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt="Publishing Controls and Social Posting"
-                  className="Pinpoint Image  "
+                  className="Pinpoint Image   medium-zoom-body"
                   decoding="async"
                   height={900}
                   loading="eager"
@@ -7157,7 +7157,7 @@ exports[`Test with pagination 1`] = `
                 >
                   <img
                     alt=""
-                    className="Pinpoint Image  "
+                    className="Pinpoint Image"
                     decoding="async"
                     height={540}
                     loading="lazy"
@@ -7266,7 +7266,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image avatar "
+                  className="Pinpoint Image avatar"
                   decoding="async"
                   height={128}
                   loading="lazy"
@@ -7496,7 +7496,7 @@ exports[`Test with pagination 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Prebuilt/__test__/__snapshots__/PrebuiltError.test.tsx.snap
+++ b/src/components/Prebuilt/__test__/__snapshots__/PrebuiltError.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Test default internal server error 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image image "
+              className="Pinpoint Image image"
               decoding="async"
               height={320}
               loading="lazy"
@@ -80,7 +80,7 @@ exports[`Test default internal server error 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -363,7 +363,7 @@ exports[`Test default not found 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image image "
+              className="Pinpoint Image image"
               decoding="async"
               height={320}
               loading="lazy"
@@ -419,7 +419,7 @@ exports[`Test default not found 1`] = `
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -702,7 +702,7 @@ exports[`Test internal server error no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image image "
+              className="Pinpoint Image image"
               decoding="async"
               height={320}
               loading="lazy"
@@ -766,7 +766,7 @@ exports[`Test not found no footer 1`] = `
           >
             <img
               alt=""
-              className="Pinpoint Image image "
+              className="Pinpoint Image image"
               decoding="async"
               height={320}
               loading="lazy"

--- a/src/components/Prebuilt/__test__/__snapshots__/PrebuiltHeader.test.tsx.snap
+++ b/src/components/Prebuilt/__test__/__snapshots__/PrebuiltHeader.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Test custom basepath 1`] = `
       >
         <img
           alt=""
-          className="Pinpoint Image image "
+          className="Pinpoint Image image"
           decoding="async"
           height={320}
           loading="lazy"
@@ -145,7 +145,7 @@ exports[`Test custom className 1`] = `
       >
         <img
           alt=""
-          className="Pinpoint Image image "
+          className="Pinpoint Image image"
           decoding="async"
           height={320}
           loading="lazy"
@@ -272,7 +272,7 @@ exports[`Test default state 1`] = `
       >
         <img
           alt=""
-          className="Pinpoint Image image "
+          className="Pinpoint Image image"
           decoding="async"
           height={320}
           loading="lazy"

--- a/src/components/Prebuilt/__test__/__snapshots__/PrebuiltHome.test.tsx.snap
+++ b/src/components/Prebuilt/__test__/__snapshots__/PrebuiltHome.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Hidden stats 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -1167,7 +1167,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1453,7 +1453,7 @@ exports[`Test custom className 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -3663,7 +3663,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -3949,7 +3949,7 @@ exports[`Test custom latest length 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -6159,7 +6159,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -6445,7 +6445,7 @@ exports[`Test default state 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -8655,7 +8655,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -8941,7 +8941,7 @@ exports[`Test default state with partial analytics 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -11151,7 +11151,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Prebuilt/__test__/__snapshots__/PrebuiltSearchResults.test.tsx.snap
+++ b/src/components/Prebuilt/__test__/__snapshots__/PrebuiltSearchResults.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Hidden stats 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -1141,7 +1141,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -1427,7 +1427,7 @@ exports[`Test custom className 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -3611,7 +3611,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"
@@ -3897,7 +3897,7 @@ exports[`Test default state 1`] = `
             >
               <img
                 alt=""
-                className="Pinpoint Image image "
+                className="Pinpoint Image image"
                 decoding="async"
                 height={320}
                 loading="lazy"
@@ -6081,7 +6081,7 @@ populated with your recently completed...
               >
                 <img
                   alt=""
-                  className="Pinpoint Image image "
+                  className="Pinpoint Image image"
                   decoding="async"
                   height={320}
                   loading="lazy"

--- a/src/components/Recent/__test__/__snapshots__/Recent.test.tsx.snap
+++ b/src/components/Recent/__test__/__snapshots__/Recent.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Test custom className 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -206,7 +206,7 @@ exports[`Test double 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -377,7 +377,7 @@ exports[`Test double 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -574,7 +574,7 @@ exports[`Test page counts 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -745,7 +745,7 @@ exports[`Test page counts 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -933,7 +933,7 @@ exports[`Test single 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1121,7 +1121,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1292,7 +1292,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1463,7 +1463,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="

--- a/src/components/Renderer/__test__/__snapshots__/RendererContent.test.tsx.snap
+++ b/src/components/Renderer/__test__/__snapshots__/RendererContent.test.tsx.snap
@@ -283,7 +283,7 @@ exports[`Test Image cover media with blurhash 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image  "
+        className="Pinpoint Image"
         decoding="async"
         loading="eager"
         src="https://file.edge.pinpoint.com/b1ee49fa5ea82ea3b71d0101ddc28a84"
@@ -305,7 +305,7 @@ exports[`Test Image cover media with blurhash in url 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image  "
+        className="Pinpoint Image"
         decoding="async"
         height={1344}
         loading="eager"
@@ -331,7 +331,7 @@ exports[`Test Image cover media with no zoom 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image  "
+        className="Pinpoint Image"
         decoding="async"
         loading="eager"
         src="https://file.edge.pinpoint.com/b1ee49fa5ea82ea3b71d0101ddc28a84"
@@ -353,7 +353,7 @@ exports[`Test Image cover media with zoom 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image  "
+        className="Pinpoint Image   medium-zoom-body"
         decoding="async"
         loading="eager"
         src="https://file.edge.pinpoint.com/b1ee49fa5ea82ea3b71d0101ddc28a84"
@@ -1303,7 +1303,7 @@ exports[`Test simple image block 1`] = `
     >
       <img
         alt="Image Caption"
-        className="Pinpoint Image  "
+        className="Pinpoint Image"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1335,7 +1335,7 @@ exports[`Test simple image block with link 1`] = `
       >
         <img
           alt="Image Caption"
-          className="Pinpoint Image  "
+          className="Pinpoint Image"
           decoding="async"
           loading="lazy"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1363,7 +1363,7 @@ exports[`Test simple image block with no zoom 1`] = `
     >
       <img
         alt="Image Caption"
-        className="Pinpoint Image  "
+        className="Pinpoint Image"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1422,7 +1422,7 @@ exports[`Test simple inline image 1`] = `
   <div>
     <img
       alt="card"
-      className="Pinpoint Image inline_image "
+      className="Pinpoint Image inline_image"
       decoding="async"
       loading="lazy"
       src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1443,7 +1443,7 @@ exports[`Test simple inline image with link 1`] = `
     >
       <img
         alt="card"
-        className="Pinpoint Image inline_image "
+        className="Pinpoint Image inline_image"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="

--- a/src/components/Renderer/content.tsx
+++ b/src/components/Renderer/content.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from 'react';
-import Zoom from 'react-medium-image-zoom';
 import {
 	addFileExtension, extractImageMetadataFromFileID, isFileAPI
 } from '../../lib/file_metadata';
@@ -24,7 +23,7 @@ const ImageMedia = ({
 }) => {
 	const { size, blurhash: _blurhash } = extractImageMetadataFromFileID(src ?? '');
 
-	const img = (
+	return (
 		<div className="Pinpoint image">
 			<Image
 				src={src}
@@ -33,15 +32,10 @@ const ImageMedia = ({
 				height={size?.height}
 				blurhash={blurhash ?? _blurhash}
 				lazy={false}
+				zoomable={zoomable}
 			/>
 		</div>
 	);
-
-	if (zoomable && typeof window !== 'undefined') {
-		return <Zoom>{img}</Zoom>;
-	}
-
-	return img;
 };
 
 const VideoMedia = ({ src, type, poster }: { src: string; type: string; poster?: string }) => {

--- a/src/components/Renderer/image_block.tsx
+++ b/src/components/Renderer/image_block.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Zoom from 'react-medium-image-zoom';
 import { extractImageMetadataFromFileID } from '../../lib/file_metadata';
 import Image from '../Image';
 import { NodeProps } from './register';
@@ -21,12 +20,9 @@ const InlineImage = ({
 }) => {
 	const img = (
 		<div className="image">
-			<Image src={src} width={scaledWidth} height={scaledHeight} alt={alt} blurhash={blurhash} />
+			<Image src={src} width={scaledWidth} height={scaledHeight} alt={alt} blurhash={blurhash} zoomable={zoom} />
 		</div>
 	);
-	if (zoom && typeof window !== 'undefined') {
-		return <Zoom>{img}</Zoom>;
-	}
 	return img;
 };
 

--- a/src/components/Search/__test__/__snapshots__/SearchResults.test.tsx.snap
+++ b/src/components/Search/__test__/__snapshots__/SearchResults.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Test custom className 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -204,7 +204,7 @@ exports[`Test double 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -375,7 +375,7 @@ exports[`Test double 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -596,7 +596,7 @@ exports[`Test single 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -783,7 +783,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -954,7 +954,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -1125,7 +1125,7 @@ exports[`Test triple 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image cover "
+        className="Pinpoint Image cover"
         decoding="async"
         loading="lazy"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="

--- a/src/components/Sidebar/__test__/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/components/Sidebar/__test__/__snapshots__/Sidebar.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Test custom className 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image avatar "
+        className="Pinpoint Image avatar"
         decoding="async"
         height={48}
         loading="lazy"
@@ -167,7 +167,7 @@ exports[`Test default 1`] = `
     >
       <img
         alt=""
-        className="Pinpoint Image avatar "
+        className="Pinpoint Image avatar"
         decoding="async"
         height={48}
         loading="lazy"

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -10,7 +10,7 @@ const ThemeToggle = (props: IThemeToggleProps) => {
 	const { className = '', onThemeChange, localStorageKey = 'theme' } = props;
 
 	const handleToggleTheme = useCallback(() => {
-		const element = document.getElementsByTagName('html')?.[0];
+		const element = document.documentElement;
 		if (element) {
 			if (element.classList.contains('dark')) {
 				element.classList.remove('dark');
@@ -28,7 +28,7 @@ const ThemeToggle = (props: IThemeToggleProps) => {
 		if (typeof window !== 'undefined') {
 			const localTheme = window.localStorage.getItem(localStorageKey);
 			if (localTheme) {
-				const element = document.getElementsByTagName('html')?.[0];
+				const element = document.documentElement;
 				switch (localTheme) {
 					case 'dark': {
 						element.classList.add('dark');

--- a/src/widgets/Feedback/style.css
+++ b/src/widgets/Feedback/style.css
@@ -1,9 +1,15 @@
+.Pinpoint.feedbackWrapper {
+	@apply mt-10 mb-5 border dark:border-black rounded p-4 inline-flex shadow-lg;
+	background-color: var(--page-bg-color, #fff);
+	color: var(--page-text-color, rgb(19, 18, 18));
+}
+
 .Pinpoint.Widget.Feedback {
 	@apply inline-flex flex-col items-start;
 }
 
 .Pinpoint.Widget.Feedback .title {
-	@apply font-medium mb-4 dark:text-white;
+	@apply font-medium mb-4;
 }
 
 .Pinpoint.Widget.Feedback .disclaimer {
@@ -11,11 +17,11 @@
 }
 
 .Pinpoint.Widget.Feedback textarea {
-	@apply border rounded mt-1 mb-2 p-1 text-sm disabled:bg-gray-100 disabled:text-gray-400 w-full;
+	@apply border rounded mt-1 mb-2 p-1 text-sm dark:text-black disabled:bg-gray-100 disabled:text-gray-400 dark:disabled:text-gray-500 w-full;
 }
 
 .Pinpoint.Widget.Feedback input {
-	@apply border rounded p-1 text-sm disabled:bg-gray-100 disabled:text-gray-400 w-full;
+	@apply border rounded p-1 text-sm dark:text-black disabled:bg-gray-100 disabled:text-gray-400 dark:disabled:text-gray-500 w-full;
 }
 
 .Pinpoint.Widget.Feedback button {


### PR DESCRIPTION
- Add default dark styles for feedback
- 2.0.16
- Fixed issue with dark mode for Feedback widget Fixed flash issue when dark mode is set and reloading the page (inline theme script) Fixed issue with zoom image by reverting back to previous zoom library and correctly attaching to the image and detaching in a hook
