### PR TITLE
Downgrade ESM target to ES2019 from ESNext to play nicer with storybook in external projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "3.1.3",
+	"version": "3.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pinpt/react",
-	"version": "3.1.3",
+	"version": "3.1.4",
 	"description": "The Pinpoint UI Library for React",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -6,7 +6,7 @@
 		"jsx": "react",
 		"resolveJsonModule": true,
 		"strict": true,
-		"target": "ESNext",
+		"target": "ES2019",
 		"outDir": "dist/esm"
 	},
 	"exclude": [


### PR DESCRIPTION
- Downgrade ESM target to ES2019 from ESNext to play nicer with storybook in external projects
- 3.1.4
